### PR TITLE
Update/Change Zoonavigator JDK Base Image to Adoptium JDK

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -24,7 +24,7 @@ RUN curl \
   && tar xzvf dockerize-alpine-linux-amd64-v${DOCKERIZE_VERSION}.tar.gz -C /usr/local/bin \
   && rm dockerize-alpine-linux-amd64-v${DOCKERIZE_VERSION}.tar.gz
 
-FROM node:14.18.1-buster-slim as npm
+FROM node:14.20.1-buster-slim as npm
 
 ARG APP_VERSION
 ARG DOCS_URL
@@ -108,7 +108,7 @@ RUN dockerize \
 RUN chgrp -R 0 . \
   && chmod -R g=u .
 
-FROM openjdk:11-jdk-slim
+FROM eclipse-temurin:11.0.19_7-jdk
 
 ARG APP_VERSION
 ARG DOCS_URL


### PR DESCRIPTION
Hey @elkozmon !

The official openjdk Docker image [has been deprecated for some time now](https://github.com/docker-library/openjdk/issues/505). It's suggested to switch either to a commercial one or to the Adoptium (aka eclipse-temurin) one. 

I changed the version of the base image to the latest JDK 11 temurin version (`eclipse-temurin:11.0.19_7-jdk`). It would be nice to release a new version with the latest JDK 11 version in order to support recent containerization features (eg: [cgroup v2](https://bugs.openjdk.org/browse/JDK-8230305)).

The node build was also broken. Angular CLI now requires Node v14.20+ to compile, so I also bumped the builder image to `node:14.20.1-buster-slim`.