### PR TITLE
Pin Angular CLI to a Node 14 compatible version (15.2.0)

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN dockerize \
     -template ./environment.ts.template:./src/environments/environment.prod.ts
 
 # Install dependencies & build
-RUN npm install -g @angular/cli \
+RUN npm install -g @angular/cli@15.2.0 \
   && npm install \
   && ng build --prod \
   && mv dist /app


### PR DESCRIPTION
Hey @elkozmon!

One last thing to fix CI with the current node/sbt/scala versions.

Angular CLI is only compatible with node 14 up to 15.2.0. I've pinned the version in the Dockerfile. It should fix the docker build until the zoonavigator-web is bumped to a more recent node version.