### PR TITLE
ci: automate snap security rebuilds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -286,7 +286,8 @@ jobs:
           ZK_TEST_NODE: /test-${{ matrix.platform }}-${{ github.run_id }}
           ZK_CONNECTION_STRING: localhost:${{ env.ZK_PORT }}
           ZN_BASE_URL: http://localhost:${{ env.ZN_PORT }}
-        run: npm test
+        run: |
+          npm test
 
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/rebuild-latest-snap.yml
+++ b/.github/workflows/rebuild-latest-snap.yml
@@ -1,0 +1,147 @@
+name: Rebuild latest Snap
+
+on:
+  schedule:
+    - cron: '17 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: rebuild-latest-snap
+  cancel-in-progress: false
+
+jobs:
+  check-stable-snap:
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture:
+          - amd64
+          - arm64
+    runs-on: ${{ matrix.architecture == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    steps:
+      - name: Install review tools
+        run: |
+          set -euo pipefail
+
+          sudo apt-get update
+          sudo apt-get install -y jq snapd
+          sudo snap install review-tools
+
+      - name: Download stable Snap
+        run: |
+          set -euo pipefail
+
+          snap download zoonavigator \
+            --channel=stable \
+            --basename=zoonavigator-stable-${{ matrix.architecture }}
+
+      - name: Check Ubuntu Security Notices
+        run: |
+          set -euo pipefail
+
+          for attempt in 1 2 3; do
+            if /snap/bin/review-tools.check-notices \
+              zoonavigator-stable-${{ matrix.architecture }}.snap \
+              | tee notices-${{ matrix.architecture }}.json
+            then
+              break
+            fi
+
+            if (( attempt == 3 )); then
+              exit 1
+            fi
+
+            echo "check-notices failed; retrying in 30 seconds."
+            sleep 30
+          done
+
+          package_count="$(
+            jq '[.[][] | keys | length] | add // 0' \
+              notices-${{ matrix.architecture }}.json
+          )"
+
+          if (( package_count > 0 )); then
+            echo "Found USN notices for ${package_count} package(s)."
+          else
+            echo "No USN notices found."
+          fi
+
+      - name: Upload notices
+        uses: actions/upload-artifact@v4
+        with:
+          name: notices-${{ matrix.architecture }}
+          path: notices-${{ matrix.architecture }}.json
+          if-no-files-found: error
+
+  dispatch-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - check-stable-snap
+    steps:
+      - name: Download notices
+        uses: actions/download-artifact@v4
+        with:
+          path: notices
+          pattern: notices-*
+          merge-multiple: true
+
+      - name: Decide whether to rebuild
+        id: notices
+        run: |
+          set -euo pipefail
+
+          package_count="$(
+            jq -s '[.[] | .[][] | keys | length] | add // 0' notices/*.json
+          )"
+
+          if (( package_count > 0 )); then
+            echo "has-notices=true" >> "$GITHUB_OUTPUT"
+            echo "Found USN notices for ${package_count} package(s); dispatching publish workflow."
+          else
+            echo "has-notices=false" >> "$GITHUB_OUTPUT"
+            echo "No USN notices found; skipping publish workflow."
+          fi
+
+      - name: Find latest version tag
+        if: steps.notices.outputs.has-notices == 'true'
+        id: latest-version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          tags="$(
+            gh api --paginate "repos/${REPOSITORY}/tags?per_page=100" --jq '.[].name' \
+              | grep -E '^v?[0-9]+(\.[0-9]+){2,3}$' \
+              || true
+          )"
+          latest_tag="$(
+            printf '%s\n' "${tags}" \
+              | awk '{ version = $0; sub(/^v/, "", version); print version, $0 }' \
+              | sort -k1,1V \
+              | tail -n 1 \
+              | awk '{ print $2 }'
+          )"
+
+          if [[ -z "${latest_tag}" ]]; then
+            echo "No semver release tag found." >&2
+            exit 1
+          fi
+
+          echo "tag=${latest_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger publish workflow
+        if: steps.notices.outputs.has-notices == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          TAG: ${{ steps.latest-version.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          gh workflow run publish.yml --repo "${REPOSITORY}" --ref "${TAG}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,6 +124,7 @@ jobs:
 
   test-build:
     if: |
+      !failure() &&
       !cancelled() &&
       inputs.skip-build != true
     uses: ./.github/workflows/build.yml


### PR DESCRIPTION
## Summary

- Add a scheduled/manual workflow that downloads the currently published stable Snap for amd64 and arm64.
- Run `review-tools.check-notices` against each architecture and dispatch `publish.yml` at the latest semver tag only when USN notices are found.
- Retry the notice check to tolerate transient Canonical USN database download/checksum failures.

## Testing

- Validated the workflow YAML locally.
- Tested via temporary branch dry-run: https://github.com/elkozmon/zoonavigator/actions/runs/26254176676
  - downloaded both stable snaps
  - found notices for `bind9-host` and `bind9-libs` on both architectures
  - resolved latest tag `2.0.0`
  - dry-ran the publish dispatch instead of publishing