### PR TITLE
ci: group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,96 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Lisbon"
+    open-pull-requests-limit: 5
+    groups:
+      web-angular-major:
+        patterns:
+          - "@angular*"
+          - "@angular-devkit/*"
+        update-types:
+          - "major"
+      web-angular-minor-patch:
+        patterns:
+          - "@angular*"
+          - "@angular-devkit/*"
+        update-types:
+          - "minor"
+          - "patch"
+      web-angular-security:
+        applies-to: "security-updates"
+        patterns:
+          - "@angular*"
+          - "@angular-devkit/*"
+      web-npm-minor-patch:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "@angular*"
+          - "@angular-devkit/*"
+        update-types:
+          - "minor"
+          - "patch"
+      web-npm-security-minor-patch:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "@angular*"
+          - "@angular-devkit/*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/e2e"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Lisbon"
+    open-pull-requests-limit: 5
+    groups:
+      e2e-npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      e2e-npm-security-minor-patch:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "pip"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Lisbon"
+    groups:
+      docs-python:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Lisbon"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds Dependabot grouping for npm, pip, and GitHub Actions updates to reduce PR volume and separate Angular-related updates from lower-risk dependency batches.