### PR TITLE
ci: add stable required test check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,3 +161,20 @@ jobs:
         working-directory: docs
         run: |
           sphinx-build -b linkcheck . _build/linkcheck
+
+  test-required:
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - test-api
+      - test-web
+      - test-e2e
+      - test-build
+      - test-docs
+    steps:
+      - name: Check required test results
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1
+
+      - name: Required tests passed
+        run: echo "Required tests passed"


### PR DESCRIPTION
## Summary

Adds a stable `test-required` job to the top-level test workflow.

The job runs after API, web, e2e, build, and docs checks and fails if any required dependency failed or was cancelled. Skipped dependencies remain acceptable, which gives the repository one fixed required check name for branch protection instead of depending on dynamic reusable workflow check names.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test.yml"); puts "test.yml: ok"'`