### PR TITLE
ci: keep Docker test image tag local

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
 
           {
             echo "outputs<<EOF"
-            echo 'type=docker,dest=${{ runner.temp }}/docker-image/image.tar'
+            echo 'type=docker,dest=${{ runner.temp }}/docker-image/image.tar,name=zoonavigator-test:${{ needs.setup-env.outputs.app-version }}-${{ matrix.architecture }}'
             if [[ "${{ inputs.publish }}" == "true" ]]; then
               echo 'type=image,"name=${{ env.DOCKER_IMAGE }}",push-by-digest=true,push=true'
             fi
@@ -108,7 +108,6 @@ jobs:
           context: .
           file: ${{ github.workspace }}/build/docker/Dockerfile
           platforms: linux/${{ matrix.architecture }}
-          tags: ${{ env.DOCKER_IMAGE }}:${{ needs.setup-env.outputs.app-version }}-${{ matrix.architecture }}
           push: false
           outputs: ${{ steps.docker-output.outputs.outputs }}
           build-args: |
@@ -241,7 +240,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          image="${{ env.DOCKER_IMAGE }}:${{ needs.setup-env.outputs.app-version }}-${{ matrix.architecture }}"
+          image="zoonavigator-test:${{ needs.setup-env.outputs.app-version }}-${{ matrix.architecture }}"
           echo "Using image '${image}'"
 
           docker run -d \


### PR DESCRIPTION
## Summary
- keep the Docker test image tag local to the tar artifact
- remove the public repository tag from the per-architecture digest build
- keep Docker Hub publication controlled by the existing manifest step

## Root Cause
The publish build added a per-architecture tag such as elkozmon/zoonavigator:latest-<sha>-arm64 while also using push-by-digest=true. Buildx rejected that with: can't push tagged ref ... by digest.

## Validation
- git diff --check
- ruby -e "require \"yaml\"; YAML.load_file(\".github/workflows/build.yml\")"