### PR TITLE
Fix docs linkcheck for placeholder domain

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -177,5 +177,8 @@ epub_title = project
 epub_exclude_files = ['search.html']
 
 # Linkcheck configuration
-linkcheck_ignore = [r'https?://localhost']
+linkcheck_ignore = [
+    r'https?://localhost',
+    r'https?://www\.your-domain\.com(?:/.*)?',
+]
 linkcheck_anchors_ignore = [r'issue-\d+']


### PR DESCRIPTION
Add the placeholder `www.your-domain.com` URL pattern to Sphinx `linkcheck_ignore`