### PR TITLE
ci: add GitHub Actions job timeouts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ permissions:
 jobs:
   setup-env:
     runs-on: ${{ inputs.runner-amd64 }}
+    timeout-minutes: 5
     outputs:
       app-version: ${{ steps.set-vars.outputs.app-version }}
       snap-channel: ${{ steps.set-vars.outputs.snap-channel }}
@@ -61,6 +62,7 @@ jobs:
           - amd64
           - arm64
     runs-on: ${{ matrix.architecture == 'arm64' && inputs.runner-arm64 || inputs.runner-amd64 }}
+    timeout-minutes: 90
     needs:
       - setup-env
     steps:
@@ -160,6 +162,7 @@ jobs:
           - amd64
           - arm64
     runs-on: ${{ matrix.architecture == 'arm64' && inputs.runner-arm64 || inputs.runner-amd64 }}
+    timeout-minutes: 60
     needs:
       - setup-env
       - build-docker
@@ -208,6 +211,7 @@ jobs:
           - amd64
           - arm64
     runs-on: ${{ matrix.architecture == 'arm64' && inputs.runner-arm64 || inputs.runner-amd64 }}
+    timeout-minutes: 30
     env:
       ZK_PORT: 2181
       ZN_PORT: 9000
@@ -326,6 +330,7 @@ jobs:
 
   publish-docker:
     runs-on: ${{ inputs.runner-amd64 }}
+    timeout-minutes: 15
     if: inputs.publish
     needs:
       - build-docker
@@ -374,6 +379,7 @@ jobs:
           - amd64
           - arm64
     runs-on: ${{ inputs.runner-amd64 }}
+    timeout-minutes: 15
     if: inputs.publish
     needs:
       - setup-env
@@ -397,6 +403,7 @@ jobs:
 
   cleanup:
     runs-on: ${{ inputs.runner-amd64 }}
+    timeout-minutes: 10
     if: always()
     needs:
       - build-docker

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       api: ${{ steps.changes.outputs.api }}
       web: ${{ steps.changes.outputs.web }}

--- a/.github/workflows/rebuild-latest-snap.yml
+++ b/.github/workflows/rebuild-latest-snap.yml
@@ -22,6 +22,7 @@ jobs:
           - amd64
           - arm64
     runs-on: ${{ matrix.architecture == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    timeout-minutes: 45
     steps:
       - name: Install review tools
         run: |
@@ -106,6 +107,7 @@ jobs:
 
   dispatch-publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       - check-stable-snap
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ permissions:
 jobs:
   test-api:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     if: inputs.skip-api != true
     steps:
       - uses: actions/checkout@v6
@@ -65,6 +66,7 @@ jobs:
 
   test-web:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: inputs.skip-web != true
     steps:
       - uses: actions/checkout@v6
@@ -101,6 +103,7 @@ jobs:
 
   test-e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: inputs.skip-e2e != true
     steps:
       - uses: actions/checkout@v6
@@ -136,6 +139,7 @@ jobs:
 
   test-docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     if: inputs.skip-docs != true
     steps:
       - uses: actions/checkout@v6
@@ -164,6 +168,7 @@ jobs:
 
   test-required:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: always()
     needs:
       - test-api


### PR DESCRIPTION
## Summary
- add job-level timeout-minutes to concrete GitHub Actions jobs
- cover reusable test/build workflows plus standalone PR and Snap rebuild jobs
- avoid per-step timeout settings

## Verification
- ruby YAML parse for .github/workflows/*.yml
- nix shell nixpkgs#actionlint -c actionlint -shellcheck=

Note: actionlint with ShellCheck enabled still reports existing shell script warnings unrelated to this change.