### PR TITLE
fix(web): resolve Dependabot vulnerabilities

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -19,7 +19,6 @@
         "@angular/platform-browser": "^21.2.15",
         "@angular/platform-browser-dynamic": "^21.2.15",
         "@angular/router": "^21.2.15",
-        "align-yaml": "^0.1.8",
         "buffer": "^5.2.1",
         "file-saver": "^2.0.0",
         "firacode": "^1.205.0",
@@ -6688,24 +6687,6 @@
         "node": ">= 14.0.0"
       }
     },
-    "node_modules/align-yaml": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/align-yaml/-/align-yaml-0.1.8.tgz",
-      "integrity": "sha512-Fqw0/tlDSu4CTBVGGNtheUc078mbiDU6hfB2gxvNyatG3TEAq3JCVOSjEnuQJfhjDismBlE2eR0yhRXS0jkD+w==",
-      "dependencies": {
-        "fs-utils": "~0.4.0",
-        "longest": "~0.2.1",
-        "minimist": "~0.0.8",
-        "repeat-string": "~0.1.0",
-        "verbalize": "~0.1.2"
-      },
-      "bin": {
-        "align": "bin/align"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -6802,21 +6783,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/argparse": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
-      "integrity": "sha512-LjmC2dNpdn2L4UzyoaIr11ELYoLn37ZFy9zObrQFHsSuOepeUEMKnM8w5KL4Tnrp2gy88rRuQt6Ky8Bjml+Baw==",
-      "license": "MIT",
-      "dependencies": {
-        "underscore": "~1.7.0",
-        "underscore.string": "~2.4.0"
-      }
-    },
-    "node_modules/argparse/node_modules/underscore": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-      "integrity": "sha512-cp0oQQyZhUM1kpJDLdGO1jPZHgS/MpzoWYfe9+CM2h/QGDZlqwT2T3YGukuBdaNJ/CAPoeyAZRRHz8JFo176vA=="
-    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -6836,11 +6802,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/async": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.6.2.tgz",
-      "integrity": "sha512-fWbn+CMBgn1KOL/UvYdsmH+gMN/fW+lzAoadt4VUFvB/t0pB4aY9RfRCCvhoA58jocHyYm5TGbeuZsPc9i1Cpg=="
     },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
@@ -8673,18 +8634,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/esprima": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-      "integrity": "sha512-rp5dMKN8zEs9dfi9g0X1ClLmV//WRyk/R15mppFNICIFRG5P92VP7Z04p8pk++gABo9W2tY+kHyu6P1mEHgmTA==",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/esrecurse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
@@ -9105,23 +9054,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/fs-utils": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/fs-utils/-/fs-utils-0.4.3.tgz",
-      "integrity": "sha512-8QI7+QjKfm5RZPkAEEwKZsltqlbUTPIgtPljVLr0ijTy62W3j8I/znThOpwMnj8pfFyPB8YAkj6Bx5dy7gYHUg==",
-      "dependencies": {
-        "async": "~0.6.2",
-        "globule": "~0.2.0",
-        "graceful-fs": "~2.0.3",
-        "js-yaml": "~3.0.2",
-        "lodash": "~2.4.1",
-        "mkdirp": "~0.3.5",
-        "rimraf": "~2.2.6"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -9226,20 +9158,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "BSD",
-      "dependencies": {
-        "inherits": "2",
-        "minimatch": "0.3"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -9276,39 +9194,6 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
-    "node_modules/glob/node_modules/lru-cache": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ==",
-      "license": "ISC"
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-      "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
-      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
-      "license": "MIT",
-      "dependencies": {
-        "lru-cache": "2",
-        "sigmund": "~1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/globule": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-0.2.0.tgz",
-      "integrity": "sha512-mMhYxzb8wpE7VtHkJi+jk0yjlBLFetYMAnkcFutmDo4uSFAHu/1tLgVm9Y6HcaTaX1DZBJjZOM1KqqCZDvBLBw==",
-      "dependencies": {
-        "glob": "~3.2.7",
-        "lodash": "~2.4.1",
-        "minimatch": "~0.2.11"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -9320,16 +9205,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/graceful-fs": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
-      "integrity": "sha512-hcj/NTUWv+C3MbqrVb9F+aH6lvTwEHJdx2foBxlrVq5h6zE8Bfu4pv4CAAqbDcZrw/9Ak5lsRXlY9Ao8/F0Tuw==",
-      "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
-      "license": "BSD",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/hammerjs": {
@@ -9346,15 +9221,6 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true
-    },
-    "node_modules/has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha512-kaNz5OTAYYmt646Hkqw50/qyxP2vFnTVu5AQ1Zmk22Kk5+4Qx6BpO8+u7IKsML5fOsFk0ZT0AcCJNYwcvaLBvw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -9779,6 +9645,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -10361,19 +10228,6 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/js-yaml": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
-      "integrity": "sha512-8PVwV1480dnAPMj8FCW3I/mZZ+gvtOoMAZFWJKagkFq2eWv5kcyzWTR+6MloV0SY57t6jSIaKc7DIz86K9ZCfA==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "~ 0.1.11",
-        "esprima": "~ 1.0.2"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -11359,16 +11213,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
-      "engines": [
-        "node",
-        "rhino"
-      ],
-      "license": "MIT"
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -11482,11 +11326,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/longest": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-0.2.1.tgz",
-      "integrity": "sha512-osx2OOPje+uhdNUX6gMFzUR0XGasF3Ditd7qAGHEjvavAhWzmS1OUbwSHlPV/a5HupMhglQszNx4zsLT6GCydQ=="
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -11744,32 +11583,6 @@
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "dev": true
     },
-    "node_modules/minimatch": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-      "integrity": "sha512-zZ+Jy8lVWlvqqeM8iZB7w7KmQkoJn8djM585z88rywrEbzoqawVa9FR5p2hwD+y74nfuKOjmNvi9gtWJNLqHvA==",
-      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
-      "license": "MIT",
-      "dependencies": {
-        "lru-cache": "2",
-        "sigmund": "~1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/minimatch/node_modules/lru-cache": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ==",
-      "license": "ISC"
-    },
-    "node_modules/minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
-      "license": "MIT"
-    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -11901,13 +11714,6 @@
       "engines": {
         "node": ">= 18"
       }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-      "integrity": "sha512-8OCq0De/h9ZxseqzCH8Kw/Filf5pF/vMI6+BH7Lu0jXz2pqYCjTAQRolSxRIi+Ax+oCCjlxoJMP0YQ4XlrQNHg==",
-      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-      "license": "MIT"
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
@@ -13265,14 +13071,6 @@
         "regjsparser": "bin/parser"
       }
     },
-    "node_modules/repeat-string": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.1.2.tgz",
-      "integrity": "sha512-ZgZWQ3i3QK1tdHaBejijHFIX/C3bUymlPXA9g+oYLlUNDEewUDluGYloiUZqiizy+XHZDJ8izGRGYcTq7xhGOQ==",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -13407,16 +13205,6 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/rimraf": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-      "integrity": "sha512-R5KMKHnPAQaZMqLOsyuyUmcIjSeDm+73eoqQpaXA7AZ22BL+6C+1mcUscgOsNd8WVlJuvlgAPsegcx7pjlV0Dg==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "MIT",
-      "bin": {
-        "rimraf": "bin.js"
-      }
     },
     "node_modules/roboto-fontface": {
       "version": "0.10.0",
@@ -14024,12 +13812,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
-      "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
@@ -15229,14 +15011,6 @@
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "license": "MIT"
     },
-    "node_modules/underscore.string": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
-      "integrity": "sha512-yxkabuCaIBnzfIvX3kBxQqCs0ar/bfJwDnFEHJUm/ZrRVhT3IItdRF5cZjARLzEnyQYtIUhsZ2LG2j3HidFOFQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/undici": {
       "version": "7.24.4",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
@@ -15365,13 +15139,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -15399,53 +15177,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/verbalize": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/verbalize/-/verbalize-0.1.2.tgz",
-      "integrity": "sha512-np7jPE3fqF3KHwZJ6hy+3O/E4DwYVZtktw0I6viZsaCxOzq1WRUdBf9O0Ur3qKa1qcvftpvvljiLyRUIYcMNhw==",
-      "dependencies": {
-        "chalk": "~0.4.0"
-      },
-      "engines": {
-        "node": ">=0.10.0",
-        "npm": ">=1.2.10"
-      }
-    },
-    "node_modules/verbalize/node_modules/ansi-styles": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-      "integrity": "sha512-3iF4FIKdxaVYT3JqQuY3Wat/T2t7TRbbQ94Fu50ZUCbLy4TFbTzr90NOHQodQkNqmeEGCw8WbeP78WNi6SKYUA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/verbalize/node_modules/chalk": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-      "integrity": "sha512-sQfYDlfv2DGVtjdoQqxS0cEZDroyG8h6TamA6rvxwlrU5BaSLDx9xhatBYl2pxZ7gmpNaPFVwBtdGdu5rQ+tYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "~1.0.0",
-        "has-color": "~0.1.0",
-        "strip-ansi": "~0.1.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/verbalize/node_modules/strip-ansi": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-      "integrity": "sha512-behete+3uqxecWlDAm5lmskaSaISA+ThQ4oNNBDTBJt0x2ppR6IPqfZNuj6BLaLJ/Sji4TPZlcRyOis8wXQTLg==",
-      "license": "MIT",
-      "bin": {
-        "strip-ansi": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/vite": {
@@ -15654,10 +15385,11 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.3.tgz",
-      "integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
+      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -16859,7 +16591,7 @@
         "tslib": "2.8.1",
         "webpack": "5.105.2",
         "webpack-dev-middleware": "7.4.5",
-        "webpack-dev-server": "5.2.3",
+        "webpack-dev-server": "5.2.4",
         "webpack-merge": "6.0.1",
         "webpack-subresource-integrity": "5.1.0"
       },
@@ -20668,18 +20400,6 @@
         "@algolia/requester-node-http": "5.48.1"
       }
     },
-    "align-yaml": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/align-yaml/-/align-yaml-0.1.8.tgz",
-      "integrity": "sha512-Fqw0/tlDSu4CTBVGGNtheUc078mbiDU6hfB2gxvNyatG3TEAq3JCVOSjEnuQJfhjDismBlE2eR0yhRXS0jkD+w==",
-      "requires": {
-        "fs-utils": "~0.4.0",
-        "longest": "~0.2.1",
-        "minimist": "~0.0.8",
-        "repeat-string": "~0.1.0",
-        "verbalize": "~0.1.2"
-      }
-    },
     "ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -20735,22 +20455,6 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
-    "argparse": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
-      "integrity": "sha512-LjmC2dNpdn2L4UzyoaIr11ELYoLn37ZFy9zObrQFHsSuOepeUEMKnM8w5KL4Tnrp2gy88rRuQt6Ky8Bjml+Baw==",
-      "requires": {
-        "underscore": "~1.7.0",
-        "underscore.string": "~2.4.0"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-          "integrity": "sha512-cp0oQQyZhUM1kpJDLdGO1jPZHgS/MpzoWYfe9+CM2h/QGDZlqwT2T3YGukuBdaNJ/CAPoeyAZRRHz8JFo176vA=="
-        }
-      }
-    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -20767,11 +20471,6 @@
         "pvutils": "^1.1.5",
         "tslib": "^2.8.1"
       }
-    },
-    "async": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.6.2.tgz",
-      "integrity": "sha512-fWbn+CMBgn1KOL/UvYdsmH+gMN/fW+lzAoadt4VUFvB/t0pB4aY9RfRCCvhoA58jocHyYm5TGbeuZsPc9i1Cpg=="
     },
     "autoprefixer": {
       "version": "10.4.27",
@@ -21974,11 +21673,6 @@
         "estraverse": "^4.1.1"
       }
     },
-    "esprima": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-      "integrity": "sha512-rp5dMKN8zEs9dfi9g0X1ClLmV//WRyk/R15mppFNICIFRG5P92VP7Z04p8pk++gABo9W2tY+kHyu6P1mEHgmTA=="
-    },
     "esrecurse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
@@ -22247,20 +21941,6 @@
         "minipass": "^7.0.3"
       }
     },
-    "fs-utils": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/fs-utils/-/fs-utils-0.4.3.tgz",
-      "integrity": "sha512-8QI7+QjKfm5RZPkAEEwKZsltqlbUTPIgtPljVLr0ijTy62W3j8I/znThOpwMnj8pfFyPB8YAkj6Bx5dy7gYHUg==",
-      "requires": {
-        "async": "~0.6.2",
-        "globule": "~0.2.0",
-        "graceful-fs": "~2.0.3",
-        "js-yaml": "~3.0.2",
-        "lodash": "~2.4.1",
-        "mkdirp": "~0.3.5",
-        "rimraf": "~2.2.6"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -22326,31 +22006,6 @@
         "es-object-atoms": "^1.0.0"
       }
     },
-    "glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
-      "requires": {
-        "inherits": "2",
-        "minimatch": "0.3"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-          "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ=="
-        },
-        "minimatch": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-          "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
-          "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
-          }
-        }
-      }
-    },
     "glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -22373,26 +22028,11 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
     },
-    "globule": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-0.2.0.tgz",
-      "integrity": "sha512-mMhYxzb8wpE7VtHkJi+jk0yjlBLFetYMAnkcFutmDo4uSFAHu/1tLgVm9Y6HcaTaX1DZBJjZOM1KqqCZDvBLBw==",
-      "requires": {
-        "glob": "~3.2.7",
-        "lodash": "~2.4.1",
-        "minimatch": "~0.2.11"
-      }
-    },
     "gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true
-    },
-    "graceful-fs": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
-      "integrity": "sha512-hcj/NTUWv+C3MbqrVb9F+aH6lvTwEHJdx2foBxlrVq5h6zE8Bfu4pv4CAAqbDcZrw/9Ak5lsRXlY9Ao8/F0Tuw=="
     },
     "hammerjs": {
       "version": "2.0.8",
@@ -22404,11 +22044,6 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true
-    },
-    "has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha512-kaNz5OTAYYmt646Hkqw50/qyxP2vFnTVu5AQ1Zmk22Kk5+4Qx6BpO8+u7IKsML5fOsFk0ZT0AcCJNYwcvaLBvw=="
     },
     "has-flag": {
       "version": "4.0.0",
@@ -22705,7 +22340,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "6.0.0",
@@ -23077,15 +22713,6 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
-    },
-    "js-yaml": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
-      "integrity": "sha512-8PVwV1480dnAPMj8FCW3I/mZZ+gvtOoMAZFWJKagkFq2eWv5kcyzWTR+6MloV0SY57t6jSIaKc7DIz86K9ZCfA==",
-      "requires": {
-        "argparse": "~ 0.1.11",
-        "esprima": "~ 1.0.2"
-      }
     },
     "jsesc": {
       "version": "3.1.0",
@@ -23776,11 +23403,6 @@
         "p-locate": "^5.0.0"
       }
     },
-    "lodash": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw=="
-    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -23856,11 +23478,6 @@
         "rfdc": "^1.3.0",
         "streamroller": "^3.1.5"
       }
-    },
-    "longest": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-0.2.1.tgz",
-      "integrity": "sha512-osx2OOPje+uhdNUX6gMFzUR0XGasF3Ditd7qAGHEjvavAhWzmS1OUbwSHlPV/a5HupMhglQszNx4zsLT6GCydQ=="
     },
     "lru-cache": {
       "version": "5.1.1",
@@ -24033,27 +23650,6 @@
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "dev": true
     },
-    "minimatch": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-      "integrity": "sha512-zZ+Jy8lVWlvqqeM8iZB7w7KmQkoJn8djM585z88rywrEbzoqawVa9FR5p2hwD+y74nfuKOjmNvi9gtWJNLqHvA==",
-      "requires": {
-        "lru-cache": "2",
-        "sigmund": "~1.0.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-          "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ=="
-        }
-      }
-    },
-    "minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw=="
-    },
     "minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -24149,11 +23745,6 @@
       "requires": {
         "minipass": "^7.1.2"
       }
-    },
-    "mkdirp": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-      "integrity": "sha512-8OCq0De/h9ZxseqzCH8Kw/Filf5pF/vMI6+BH7Lu0jXz2pqYCjTAQRolSxRIi+Ax+oCCjlxoJMP0YQ4XlrQNHg=="
     },
     "mrmime": {
       "version": "2.0.1",
@@ -25052,11 +24643,6 @@
         "jsesc": "~3.1.0"
       }
     },
-    "repeat-string": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.1.2.tgz",
-      "integrity": "sha512-ZgZWQ3i3QK1tdHaBejijHFIX/C3bUymlPXA9g+oYLlUNDEewUDluGYloiUZqiizy+XHZDJ8izGRGYcTq7xhGOQ=="
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -25146,11 +24732,6 @@
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true
-    },
-    "rimraf": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-      "integrity": "sha512-R5KMKHnPAQaZMqLOsyuyUmcIjSeDm+73eoqQpaXA7AZ22BL+6C+1mcUscgOsNd8WVlJuvlgAPsegcx7pjlV0Dg=="
     },
     "roboto-fontface": {
       "version": "0.10.0",
@@ -25544,11 +25125,6 @@
         "side-channel-map": "^1.0.1"
       }
     },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g=="
-    },
     "signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -25659,7 +25235,7 @@
       "dev": true,
       "requires": {
         "faye-websocket": "^0.11.3",
-        "uuid": "^8.3.2",
+        "uuid": "11.1.1",
         "websocket-driver": "^0.7.4"
       }
     },
@@ -26336,11 +25912,6 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="
     },
-    "underscore.string": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
-      "integrity": "sha512-yxkabuCaIBnzfIvX3kBxQqCs0ar/bfJwDnFEHJUm/ZrRVhT3IItdRF5cZjARLzEnyQYtIUhsZ2LG2j3HidFOFQ=="
-    },
     "undici": {
       "version": "7.24.4",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
@@ -26416,9 +25987,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true
     },
     "v8-compile-cache-lib": {
@@ -26438,36 +26009,6 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true
-    },
-    "verbalize": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/verbalize/-/verbalize-0.1.2.tgz",
-      "integrity": "sha512-np7jPE3fqF3KHwZJ6hy+3O/E4DwYVZtktw0I6viZsaCxOzq1WRUdBf9O0Ur3qKa1qcvftpvvljiLyRUIYcMNhw==",
-      "requires": {
-        "chalk": "~0.4.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "integrity": "sha512-3iF4FIKdxaVYT3JqQuY3Wat/T2t7TRbbQ94Fu50ZUCbLy4TFbTzr90NOHQodQkNqmeEGCw8WbeP78WNi6SKYUA=="
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "integrity": "sha512-sQfYDlfv2DGVtjdoQqxS0cEZDroyG8h6TamA6rvxwlrU5BaSLDx9xhatBYl2pxZ7gmpNaPFVwBtdGdu5rQ+tYQ==",
-          "requires": {
-            "ansi-styles": "~1.0.0",
-            "has-color": "~0.1.0",
-            "strip-ansi": "~0.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "integrity": "sha512-behete+3uqxecWlDAm5lmskaSaISA+ThQ4oNNBDTBJt0x2ppR6IPqfZNuj6BLaLJ/Sji4TPZlcRyOis8wXQTLg=="
-        }
-      }
     },
     "vite": {
       "version": "7.3.2",
@@ -26606,9 +26147,9 @@
       }
     },
     "webpack-dev-server": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.3.tgz",
-      "integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
+      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
       "dev": true,
       "requires": {
         "@types/bonjour": "^3.5.13",

--- a/web/package.json
+++ b/web/package.json
@@ -29,7 +29,6 @@
     "@angular/platform-browser": "^21.2.15",
     "@angular/platform-browser-dynamic": "^21.2.15",
     "@angular/router": "^21.2.15",
-    "align-yaml": "^0.1.8",
     "buffer": "^5.2.1",
     "file-saver": "^2.0.0",
     "firacode": "^1.205.0",
@@ -74,5 +73,11 @@
     "ts-node": "^10.9.2",
     "tslint": "^6.1.3",
     "typescript": "^5.9.3"
+  },
+  "overrides": {
+    "sockjs": {
+      "uuid": "11.1.1"
+    },
+    "webpack-dev-server": "5.2.4"
   }
 }


### PR DESCRIPTION
## Summary
- remove unused `align-yaml` from the web app dependency graph
- override `webpack-dev-server` to `5.2.4` and `sockjs`'s `uuid` to `11.1.1`
- regenerate `web/package-lock.json` with the patched dependency graph

## Verification
- `nix shell nixpkgs#nodejs_22 -c npm audit --json` in `web`
- `nix shell nixpkgs#nodejs_22 -c npm audit --json` in `e2e`
- `/private/tmp/zoonavigator-pip-audit-py313/bin/pip-audit -r requirements.txt --format=json --cache-dir /private/tmp/zoonavigator-pip-audit-cache-py313` in `docs`
- `nix shell nixpkgs#osv-scanner -c osv-scanner scan --recursive .`
- `nix shell nixpkgs#nodejs_22 -c npm run build` in `web`
- `nix shell nixpkgs#nodejs_22 -c npm run lint` in `web`
- `nix shell nixpkgs#nodejs_22 -c npm test -- --no-watch --no-progress` in `web`
- `git diff --check`