### PR TITLE
ci: automate dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,70 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    branches: [ master, main ]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  metadata:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+    if: |
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.draft == false
+    outputs:
+      update-type: ${{ steps.dependabot-metadata.outputs.update-type }}
+    steps:
+      - name: Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v3
+
+  auto-merge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - metadata
+    permissions:
+      contents: write
+      pull-requests: write
+    if: |
+      needs.metadata.outputs.update-type == 'version-update:semver-minor' ||
+      needs.metadata.outputs.update-type == 'version-update:semver-patch'
+    steps:
+      - name: Approve pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr review --approve "$PR_URL"
+
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          auto_merge_enabled="$(
+            gh pr view "$PR_URL" \
+              --json autoMergeRequest \
+              --jq '.autoMergeRequest != null'
+          )"
+
+          if [[ "${auto_merge_enabled}" == "true" ]]; then
+            echo "Auto-merge is already enabled."
+            exit 0
+          fi
+
+          gh pr merge --auto --merge --delete-branch "$PR_URL"


### PR DESCRIPTION
Adds a Dependabot auto-merge workflow that fetches metadata, auto-approves minor/patch PRs, and enables GitHub auto-merge after required checks pass. Major updates are left for manual review. Repository settings still need auto-merge, required checks, and Actions PR approvals enabled.