### PR TITLE
ci(dependabot): monitor backend and packaging dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,6 +71,29 @@ updates:
           - "minor"
           - "patch"
 
+  - package-ecosystem: "sbt"
+    directory: "/api"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Lisbon"
+    open-pull-requests-limit: 5
+    groups:
+      api-sbt-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      api-sbt-security-minor-patch:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "pip"
     directory: "/docs"
     schedule:
@@ -80,6 +103,32 @@ updates:
       timezone: "Europe/Lisbon"
     groups:
       docs-python:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/build/docker"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Lisbon"
+    open-pull-requests-limit: 5
+    groups:
+      docker-images:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Lisbon"
+    open-pull-requests-limit: 5
+    groups:
+      docker-compose-images:
         patterns:
           - "*"
 


### PR DESCRIPTION
Summary: Adds Dependabot coverage for sbt backend dependencies, Dockerfile base images, and docker-compose images. Validation: parsed .github/dependabot.yml with Ruby YAML and ran git diff --check.