### PR TITLE
fix(api): migrate Play backend to Pekko

### DIFF
--- a/api/play/app/AppComponents.scala
+++ b/api/play/app/AppComponents.scala
@@ -132,7 +132,7 @@ class AppComponents(context: Context)
     wire[ApplicationRouter]
   }
 
-  lazy val akkaScheduler: Scheduler =
+  lazy val pekkoScheduler: Scheduler =
     Scheduler(actorSystem.dispatcher)
 
   lazy val curatorCacheMaxAge: CuratorCacheMaxAge =

--- a/api/play/app/api/controllers/ApiController.scala
+++ b/api/play/app/api/controllers/ApiController.scala
@@ -18,7 +18,6 @@
 package api.controllers
 
 import _root_.curator.action.CuratorRequest
-import akka.util.ByteString
 import api.ApiResponse
 import api.exceptions.BadRequestException
 import api.exceptions.HttpException
@@ -26,6 +25,7 @@ import api.formats.Json._
 import config.ApplicationConfig
 import curator.action.CuratorAction
 import monix.eval.Task
+import org.apache.pekko.util.ByteString
 import play.api.http.HttpErrorHandler
 import play.api.libs.json._
 import play.api.mvc._

--- a/api/play/app/api/formats/json/api/JsonApiResponse.scala
+++ b/api/play/app/api/formats/json/api/JsonApiResponse.scala
@@ -17,9 +17,9 @@
 
 package api.formats.json.api
 
-import akka.http.scaladsl.model.MediaTypes
-import akka.util.ByteString
 import api.ApiResponse
+import org.apache.pekko.http.scaladsl.model.MediaTypes
+import org.apache.pekko.util.ByteString
 import play.api.http.Writeable
 import play.api.libs.json._
 

--- a/api/project/plugins.sbt
+++ b/api/project/plugins.sbt
@@ -3,7 +3,7 @@ logLevel := Level.Warn
 // Play
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/maven-releases/"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.2")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.11")
 
 // Scalafmt
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.5")


### PR DESCRIPTION
## Summary
- Upgrade the Play sbt plugin from Play 2.9 to Play 3.0
- Move direct Akka imports to Pekko equivalents
- Rename the backend scheduler binding away from the Akka-specific name

## Verification
- `nix shell nixpkgs#sbt nixpkgs#temurin-jre-bin-17 --command sbt scalafmtCheckAll`
- `nix shell nixpkgs#sbt nixpkgs#temurin-jre-bin-17 --command sbt test`