### PR TITLE
chore(dependabot): ignore Scala major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -79,6 +79,10 @@ updates:
       time: "06:00"
       timezone: "Europe/Lisbon"
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "org.scala-lang:scala-library"
+        update-types:
+          - "version-update:semver-major"
     groups:
       api-sbt-minor-patch:
         patterns:


### PR DESCRIPTION
## Summary
- ignore semver-major Dependabot updates for org.scala-lang:scala-library
- keep Scala 2.13 patch updates allowed while avoiding accidental Scala 3 migration PRs

## Verification
- parsed .github/dependabot.yml with Ruby YAML