### PR TITLE
fix(security): make CORS opt-in

### DIFF
--- a/api/play/conf/application.conf
+++ b/api/play/conf/application.conf
@@ -7,14 +7,10 @@ play {
   # Allow large requests (imports)
   http.parser.maxMemoryBuffer = 10m
 
-  # Allow all origins
-  filters.cors.allowedOrigins = null
-
   # Filters
   filters {
     enabled = []
     enabled += "play.filters.headers.SecurityHeadersFilter"
-    enabled += "play.filters.cors.CORSFilter"
   }
 
   # Assets

--- a/build/docker/files/api/conf/zoonavigator.conf.sh
+++ b/build/docker/files/api/conf/zoonavigator.conf.sh
@@ -1,5 +1,20 @@
 #!/usr/bin/env bash
 
+hocon_string() {
+  local escaped
+
+  escaped=$(printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  printf '"%s"' "$escaped"
+}
+
+trim() {
+  local value="$1"
+
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
 if [ -n "$REQUEST_TIMEOUT_MILLIS" ]
 then
   cat <<EOF
@@ -17,6 +32,37 @@ play.http.parser.maxMemoryBuffer = ${REQUEST_MAX_SIZE_KB}k
 
 EOF
 
+fi
+
+if [ -n "$CORS_ALLOWED_ORIGINS" ]
+then
+  IFS=',' read -ra CORS_ORIGINS <<< "$CORS_ALLOWED_ORIGINS"
+  CORS_ALLOWED_ORIGINS_HOCON=""
+
+  for CORS_ORIGIN in "${CORS_ORIGINS[@]}"
+  do
+    CORS_ORIGIN=$(trim "$CORS_ORIGIN")
+
+    if [ -n "$CORS_ORIGIN" ]
+    then
+      if [ -n "$CORS_ALLOWED_ORIGINS_HOCON" ]
+      then
+        CORS_ALLOWED_ORIGINS_HOCON="$CORS_ALLOWED_ORIGINS_HOCON, "
+      fi
+
+      CORS_ALLOWED_ORIGINS_HOCON="$CORS_ALLOWED_ORIGINS_HOCON$(hocon_string "$CORS_ORIGIN")"
+    fi
+  done
+
+  if [ -n "$CORS_ALLOWED_ORIGINS_HOCON" ]
+  then
+    cat <<EOF
+# Cross-origin browser access
+play.filters.enabled += "play.filters.cors.CORSFilter"
+play.filters.cors.allowedOrigins = [${CORS_ALLOWED_ORIGINS_HOCON}]
+
+EOF
+  fi
 fi
 
 if [ -n "$AUTO_CONNECT_CONNECTION_ID" ]

--- a/build/snap/local/bin/configure
+++ b/build/snap/local/bin/configure
@@ -42,6 +42,14 @@ enclose_quotes() {
   fi
 }
 
+trim() {
+  value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+
+  echo "$value"
+}
+
 get_conf() {
   val=$(snapctl get "$1")
 
@@ -62,12 +70,42 @@ get_conf() {
 #################################################
 
 add_appconf "play.application.loader = " "$(enclose_quotes "AppLoader")"
-add_appconf "play.filters.cors.allowedOrigins = " "null"
 add_appconf "play.filters.enabled = " "[]"
 add_appconf "play.filters.enabled += " "$(enclose_quotes "play.filters.headers.SecurityHeadersFilter")"
-add_appconf "play.filters.enabled += " "$(enclose_quotes "play.filters.cors.CORSFilter")"
 add_appconf "play.assets.path = " "$(enclose_quotes "/public")"
 add_appconf "play.assets.urlPrefix = " "$(enclose_quotes "/")"
+
+CORS_ALLOWED_ORIGINS="$(get_conf "zoonavigator.cors.allowed-origins")"
+
+if [ -n "$CORS_ALLOWED_ORIGINS" ]
+then
+  CORS_ALLOWED_ORIGINS_HOCON=""
+  OLD_IFS="$IFS"
+  IFS=","
+
+  for CORS_ORIGIN in $CORS_ALLOWED_ORIGINS
+  do
+    CORS_ORIGIN="$(trim "$CORS_ORIGIN")"
+
+    if [ -n "$CORS_ORIGIN" ]
+    then
+      if [ -n "$CORS_ALLOWED_ORIGINS_HOCON" ]
+      then
+        CORS_ALLOWED_ORIGINS_HOCON="${CORS_ALLOWED_ORIGINS_HOCON}, "
+      fi
+
+      CORS_ALLOWED_ORIGINS_HOCON="${CORS_ALLOWED_ORIGINS_HOCON}$(enclose_quotes "$CORS_ORIGIN")"
+    fi
+  done
+
+  IFS="$OLD_IFS"
+
+  if [ -n "$CORS_ALLOWED_ORIGINS_HOCON" ]
+  then
+    add_appconf "play.filters.enabled += " "$(enclose_quotes "play.filters.cors.CORSFilter")"
+    add_appconf "play.filters.cors.allowedOrigins = " "[$CORS_ALLOWED_ORIGINS_HOCON]"
+  fi
+fi
 
 AUTO_CONNECT_CONNECTION_ID="$(get_conf "zoonavigator.auto-connect.connection-id")"
 

--- a/docs/docker/configuration.rst
+++ b/docs/docker/configuration.rst
@@ -64,6 +64,17 @@ If you want ZooNavigator to be available at 'http://www.your-domain.com/zoonavig
   base href must start with '/'
 
 
+CORS_ALLOWED_ORIGINS
+--------------------
+By default, ZooNavigator does not allow browser requests from other origins.
+
+Set this variable to a comma-separated list of origins when ZooNavigator is intentionally served behind a separate frontend origin, for example :code:`https://admin.example.com,https://ops.example.com`.
+
+.. warning::
+
+  Only list origins you trust. ZooNavigator can mutate ZooKeeper data, so cross-origin browser access should be enabled deliberately and usually behind your own authentication proxy.
+
+
 REQUEST_TIMEOUT_MILLIS
 ----------------------
 *default*: :code:`10000`

--- a/docs/faqs.rst
+++ b/docs/faqs.rst
@@ -18,6 +18,14 @@ At the moment there is no configuration option to enable Basic Auth out-of-the-b
 I suggest placing a proxy which supports Basic Auth in front of ZooNavigator. For example `Traefik <https://docs.traefik.io>`_.
 
 
+How to allow cross-origin browser access?
+-----------------------------------------
+
+ZooNavigator does not allow cross-origin browser requests by default. If you intentionally serve ZooNavigator's frontend and API from different origins, configure the allowed origins explicitly with :code:`CORS_ALLOWED_ORIGINS` for Docker or :code:`zoonavigator.cors.allowed-origins` for Snap.
+
+Only list origins you trust, and prefer placing ZooNavigator behind your own authentication proxy when exposing it outside a private network.
+
+
 I'm getting error that says "Unable to establish connection with ZooKeeper."
 ----------------------------------------------------------------------------
 

--- a/docs/snap/configuration.rst
+++ b/docs/snap/configuration.rst
@@ -62,6 +62,17 @@ If you want ZooNavigator to be available at 'http://www.your-domain.com/zoonavig
   base href must start with '/'
 
 
+zoonavigator.cors.allowed-origins
+---------------------------------
+By default, ZooNavigator does not allow browser requests from other origins.
+
+Set this option to a comma-separated list of origins when ZooNavigator is intentionally served behind a separate frontend origin, for example :code:`https://admin.example.com,https://ops.example.com`.
+
+.. warning::
+
+  Only list origins you trust. ZooNavigator can mutate ZooKeeper data, so cross-origin browser access should be enabled deliberately and usually behind your own authentication proxy.
+
+
 zoonavigator.request.timeout
 ----------------------------
 *default*: :code:`10000`


### PR DESCRIPTION
## Summary
- Make CORS opt-in for the default Play, Docker, and Snap configurations.
- Add explicit Docker/Snap allowed-origin configuration docs.
- Document the trust boundary for enabling cross-origin browser access.

## Verification
- `bash -n build/docker/files/api/conf/zoonavigator.conf.sh`
- `sh -n build/snap/local/bin/configure`
- `/private/tmp/zn-docs-venv/bin/sphinx-build -W -b html docs /private/tmp/zoonavigator-docs-cors-split`