### PR TITLE
ci(pr): broaden change filters for shared files

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,11 +32,10 @@ jobs:
               - 'e2e/**'
             docs:
               - 'docs/**'
-              - '.readthedocs.yml'
             build:
               - 'build/**'
               - '.dockerignore'
-              - '.github/**'
+              - '.github/workflows/**'
 
   test:
     needs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,9 +32,11 @@ jobs:
               - 'e2e/**'
             docs:
               - 'docs/**'
+              - '.readthedocs.yml'
             build:
               - 'build/**'
-              - '.github/workflows/**'
+              - '.dockerignore'
+              - '.github/**'
 
   test:
     needs:


### PR DESCRIPTION
## Summary
- Keep PR path filters focused on files that can affect each job family.
- Treat `.dockerignore` as build-affecting input because Docker Buildx sends the repository as build context.
- Keep workflow changes scoped to `.github/workflows/**`, which can alter CI/build behavior.
- Do not treat `.readthedocs.yml`, `.envrc`, `devenv.nix`, `flake.nix`, or non-workflow `.github` files as test inputs because the current GitHub Actions do not evaluate them.

## Verification
- `nix shell nixpkgs#actionlint -c actionlint -shellcheck= .github/workflows/pr.yml`