### PR TITLE
refactor(web): tighten core storage and API typing

### DIFF
--- a/web/src/app/core/api/service/default-api.service.spec.ts
+++ b/web/src/app/core/api/service/default-api.service.spec.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019  Ľuboš Kozmon <https://www.elkozmon.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {HttpClient, HttpHeaders, HttpResponse} from "@angular/common/http";
+import {Router} from "@angular/router";
+import {of} from "rxjs";
+import {ConfigService} from "../../../config";
+import {ConnectionManager} from "../../connection/manager";
+import {DialogService} from "../../dialog";
+import {ApiRequest} from "../request";
+import {RequestMethods} from "../request/request-methods";
+import {DefaultApiService} from "./default-api.service";
+
+describe("DefaultApiService", () => {
+  it("accepts API responses with null optional fields", (done) => {
+    const httpClient = {
+      request: jasmine.createSpy("request").and.returnValue(of(new HttpResponse({
+        body: {
+          success: true,
+          message: null,
+          payload: null
+        },
+        headers: new HttpHeaders({
+          "Content-Type": "application/json"
+        }),
+        status: 200
+      })))
+    } as unknown as HttpClient;
+
+    const service = new DefaultApiService(
+      {} as Router,
+      httpClient,
+      {} as ConnectionManager,
+      {} as DialogService,
+      {
+        config: {
+          requestTimeoutMillis: 1000
+        }
+      } as ConfigService,
+      ""
+    );
+
+    service
+      .dispatch(new ApiRequest("/test", RequestMethods.Get))
+      .subscribe(response => {
+        expect(response.success).toBe(true);
+        expect(response.message).toBeNull();
+        expect(response.payload).toBeNull();
+        done();
+      });
+  });
+});

--- a/web/src/app/core/api/service/default-api.service.ts
+++ b/web/src/app/core/api/service/default-api.service.ts
@@ -30,10 +30,32 @@ import {ApiService} from "./api.service";
 import {APP_BASE_HREF} from "@angular/common";
 import {environment} from "../../../../environments/environment";
 
+interface ApiResponseBody<T> {
+  success: boolean;
+  payload?: T;
+  message?: string;
+}
+
 @Injectable()
 export class DefaultApiService implements ApiService {
 
-  private static extractResponse<T>(body: any): ApiResponse<T> {
+  private static isApiResponseBody<T>(body: unknown): body is ApiResponseBody<T> {
+    const candidate = body as {success?: unknown, message?: unknown};
+
+    return typeof body === "object" &&
+      body !== null &&
+      typeof candidate.success === "boolean" &&
+      (
+        candidate.message === undefined ||
+        typeof candidate.message === "string"
+      );
+  }
+
+  private static extractResponse<T>(body: unknown): ApiResponse<T> {
+    if (!DefaultApiService.isApiResponseBody<T>(body)) {
+      throw new Error("Malformed API response");
+    }
+
     return new ApiResponse(
       body.success,
       body.payload,
@@ -84,22 +106,20 @@ export class DefaultApiService implements ApiService {
           if (t.headers.has("Content-Type") && t.headers.get("Content-Type").startsWith("application/json")) {
             return DefaultApiService.extractResponse<T>(t.body);
           } else {
-            return { success: t.ok };
+            return new ApiResponse(t.ok);
           }
         }),
         catchError(err => this.handleError(err))
       );
   }
 
-  private handleError<T>(anyError: any): Observable<T> {
+  private handleError<T>(anyError: unknown): Observable<T> {
     let error: Error;
 
     if (typeof anyError === "string" || anyError instanceof String) {
       error = new Error(<string>anyError);
-    } else if (anyError instanceof Error) {
-      error = anyError;
     } else if (anyError instanceof HttpErrorResponse) {
-      if (anyError.error.hasOwnProperty("success")) {
+      if (DefaultApiService.isApiResponseBody<unknown>(anyError.error)) {
         error = new Error(DefaultApiService.extractResponse(anyError.error).message);
       } else {
         error = new Error(anyError.error || "Unable to receive a response");
@@ -123,6 +143,8 @@ export class DefaultApiService implements ApiService {
           )
           .subscribe();
       }
+    } else if (anyError instanceof Error) {
+      error = anyError;
     } else {
       error = new Error("Unknown error occurred. See the console for details");
       console.error(anyError);

--- a/web/src/app/core/api/service/default-api.service.ts
+++ b/web/src/app/core/api/service/default-api.service.ts
@@ -33,7 +33,7 @@ import {environment} from "../../../../environments/environment";
 interface ApiResponseBody<T> {
   success: boolean;
   payload?: T;
-  message?: string;
+  message?: string | null;
 }
 
 @Injectable()
@@ -47,6 +47,7 @@ export class DefaultApiService implements ApiService {
       typeof candidate.success === "boolean" &&
       (
         candidate.message === undefined ||
+        candidate.message === null ||
         typeof candidate.message === "string"
       );
   }

--- a/web/src/app/core/connection/manager/default-connection-manager.ts
+++ b/web/src/app/core/connection/manager/default-connection-manager.ts
@@ -16,29 +16,61 @@
  */
 
 import {Injectable} from "@angular/core";
-import {Observable, of} from "rxjs";
+import {Observable} from "rxjs";
 import {map} from "rxjs/operators";
 import {Maybe} from "tsmonad";
 import {ConnectionManager} from "./connection-manager";
 import {StorageService} from "../../storage";
 import {ConnectionPreset} from "../connection-preset";
 import {ConnectionParams} from "../connection-params";
-import {ConfigService} from "../../../config";
 
 @Injectable()
 export class DefaultConnectionManager implements ConnectionManager {
 
   private connectionKey = "DefaultConnectionManager.connection";
 
-  constructor(private storageService: StorageService, private configService: ConfigService) {
+  private static isRecord(value: unknown): value is {[key: string]: unknown} {
+    return typeof value === "object" && value !== null;
+  }
+
+  private static isConnectionPreset(value: unknown): value is ConnectionPreset {
+    return DefaultConnectionManager.isRecord(value) &&
+      typeof value.id === "string" &&
+      typeof value.connectionString === "string";
+  }
+
+  private static isConnectionParams(value: unknown): value is ConnectionParams {
+    return DefaultConnectionManager.isRecord(value) &&
+      typeof value.connectionString === "string" &&
+      Array.isArray(value.authInfo);
+  }
+
+  private static parseConnection(value: string | null): ConnectionPreset | ConnectionParams | null {
+    if (!value) {
+      return null;
+    }
+
+    try {
+      const parsed: unknown = JSON.parse(value);
+
+      return DefaultConnectionManager.isConnectionPreset(parsed) ||
+        DefaultConnectionManager.isConnectionParams(parsed)
+        ? parsed
+        : null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  constructor(private storageService: StorageService) {
   }
 
   // TODO
   observeConnection(): Observable<Maybe<ConnectionPreset | ConnectionParams>> {
     return this.storageService
-      .observe(this.connectionKey)
+      .observe<string>(this.connectionKey)
       .pipe(
-        map((value) => Maybe.maybe(value ? JSON.parse(value) : null))
+        map((value) => Maybe.maybe(DefaultConnectionManager.parseConnection(value)))
       );
   }
 

--- a/web/src/app/core/storage/local-storage.service.ts
+++ b/web/src/app/core/storage/local-storage.service.ts
@@ -24,15 +24,15 @@ import {Maybe} from "tsmonad";
 @Injectable()
 export class LocalStorageService implements StorageService {
 
-  private subjects: Map<string, Subject<any>>;
+  private subjects: Map<string, Subject<Maybe<string>>>;
   private subscription: Subscription;
 
   constructor() {
-    this.subjects = new Map<string, Subject<Maybe<any>>>();
+    this.subjects = new Map<string, Subject<Maybe<string>>>();
     this.subscription = new Subscription(() => {});
   }
 
-  private getSubject(key: string): Subject<any> {
+  private getSubject(key: string): Subject<Maybe<string>> {
     const sub = this.subjects.get(key);
 
     if (sub) {
@@ -52,15 +52,15 @@ export class LocalStorageService implements StorageService {
     return newSub;
   }
 
-  set(key: string, value: any): Observable<void> {
+  set(key: string, value: string): Observable<void> {
     return of(this.getSubject(key).next(Maybe.just(value)));
   }
 
-  observe(key: string): Observable<any> {
+  observe<T extends string = string>(key: string): Observable<T | null> {
     return this.getSubject(key).pipe(
       map(maybeValue => {
         return maybeValue.caseOf({
-          just: value => value,
+          just: value => value as T,
           nothing: () => null
         });
       })

--- a/web/src/app/core/storage/storage.service.ts
+++ b/web/src/app/core/storage/storage.service.ts
@@ -21,9 +21,9 @@ import {Observable} from "rxjs";
 @Injectable()
 export abstract class StorageService {
 
-  abstract set(key: string, value: any): Observable<void>
+  abstract set(key: string, value: string): Observable<void>
 
-  abstract observe(key: string): Observable<any>
+  abstract observe<T extends string = string>(key: string): Observable<T | null>
 
   abstract remove(key: string): Observable<void>
 }

--- a/web/src/app/editor/preferences/default-preferences.service.ts
+++ b/web/src/app/editor/preferences/default-preferences.service.ts
@@ -51,7 +51,7 @@ export class DefaultPreferencesService extends PreferencesService {
     const key = DefaultPreferencesService.getModeKey(path, creationId);
 
     return this.storageService
-      .observe(key)
+      .observe<ModeId>(key)
       .pipe(
         map(Maybe.maybe)
       );


### PR DESCRIPTION
## Summary
- Make the storage abstraction explicitly string-backed.
- Add typed storage reads for preferences and connection state.
- Validate API response bodies from `unknown` before constructing `ApiResponse`.
- Parse stored connection JSON through shape guards instead of leaking `any`.

## Verification
- `nix shell nixpkgs#nodejs_24 --command npm run lint`
- `nix shell nixpkgs#nodejs_24 --command npm run test:ci`