### PR TITLE
refactor(web): replace deprecated Buffer constructor

### DIFF
--- a/web/src/app/core/znode/api-znode.service.ts
+++ b/web/src/app/core/znode/api-znode.service.ts
@@ -57,11 +57,11 @@ export class ApiZNodeService implements ZNodeService {
   private connectionToToken(cxn: any): string {
     if (cxn.id) {
       const cxnPreset = cxn as ConnectionPreset;
-      return "CxnPreset " + new Buffer(cxnPreset.id).toString("base64");
+      return "CxnPreset " + Buffer.from(cxnPreset.id).toString("base64");
     }
 
     const cxnParams = cxn as ConnectionParams;
-    return "CxnParams " + new Buffer(JSON.stringify(cxnParams)).toString("base64");
+    return "CxnParams " + Buffer.from(JSON.stringify(cxnParams)).toString("base64");
   }
 
   getNode(path: string): Observable<ZNodeWithChildren> {


### PR DESCRIPTION
## Summary
- Replace deprecated `new Buffer(...)` usage in auth token construction with `Buffer.from(...)`.
- Confirm no remaining `new Buffer` references exist in source.

## Verification
- `nix shell nixpkgs#nodejs_24 --command npm run lint`
- `nix shell nixpkgs#nodejs_24 --command npm run test:ci`
- `rg -n "new Buffer" web/src api build e2e`