### PR TITLE
chore(github): add community health files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @elkozmon

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Report a reproducible ZooNavigator issue
+title: ""
+labels: bug
+assignees: ""
+---
+
+## Description
+
+
+## Steps To Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+
+## Environment
+
+- ZooNavigator version:
+- Package type: Docker / Snap / source
+- ZooKeeper version:
+- Browser and OS:
+
+## Logs Or Screenshots
+
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security report
+    url: mailto:contact@elkozmon.com
+    about: Please report suspected vulnerabilities privately by email.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an improvement to ZooNavigator
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+
+## Proposed Solution
+
+
+## Alternatives Considered
+
+
+## Additional Context
+
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Summary
+
+-
+
+## Verification
+
+-
+
+## Notes
+
+-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+Thanks for taking the time to improve ZooNavigator.
+
+## Development Setup
+
+The preferred workflow uses `devenv` from the repository root:
+
+```bash
+devenv shell
+devenv up
+devenv test
+```
+
+If `devenv` is not available, use the equivalent commands from the relevant subproject:
+
+- API: `cd api && sbt scalafmtCheckAll test`
+- Web: `cd web && npm ci && npm run lint && npm run test:ci`
+- Docs: `cd docs && pip install -r requirements.txt && sphinx-build -W -b html . _build/html`
+- E2E: `cd e2e && npm ci && npm run lint && npm test`
+
+## Pull Requests
+
+- Keep changes focused and explain the user-facing behavior or maintenance value.
+- Add or update tests for behavior changes.
+- Keep `package-lock.json` files in sync when changing Node dependencies.
+- Use Conventional Commit style for commit messages, for example `fix(api): handle missing acl`.
+
+## Documentation
+
+Configuration and user-facing behavior changes should update the Sphinx docs under `docs/`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-ZooNavigator can connect to and mutate ZooKeeper data, so please do not file public issues for suspected vulnerabilities.
+ZooNavigator can connect to and mutate ZooKeeper data. If you think you have found a vulnerability, please report it privately instead of opening a public issue.
 
 ## Reporting A Vulnerability
 
@@ -10,8 +10,8 @@ Email security reports to contact@elkozmon.com with:
 - Steps to reproduce, proof of concept, or relevant logs.
 - The ZooNavigator version, packaging type, and ZooKeeper version involved.
 
-Please allow a reasonable window for triage before public disclosure. If the issue is accepted, fixes will be prepared for the maintained release line and documented in the changelog.
+Please allow time for review before public disclosure. There is no formal response SLA, but accepted fixes will be handled in the default branch and included in a future release.
 
 ## Supported Versions
 
-Security fixes target the latest stable ZooNavigator release and the default branch. Older releases may receive fixes when the change can be backported safely.
+Security fixes target the default branch and the latest published release. Older releases are not maintained separately; users should upgrade when a fix is available.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+ZooNavigator can connect to and mutate ZooKeeper data, so please do not file public issues for suspected vulnerabilities.
+
+## Reporting A Vulnerability
+
+Email security reports to contact@elkozmon.com with:
+
+- A description of the issue and affected configuration.
+- Steps to reproduce, proof of concept, or relevant logs.
+- The ZooNavigator version, packaging type, and ZooKeeper version involved.
+
+Please allow a reasonable window for triage before public disclosure. If the issue is accepted, fixes will be prepared for the maintained release line and documented in the changelog.
+
+## Supported Versions
+
+Security fixes target the latest stable ZooNavigator release and the default branch. Older releases may receive fixes when the change can be backported safely.


### PR DESCRIPTION
## Summary
- Add `SECURITY.md`, `CONTRIBUTING.md`, CODEOWNERS, issue templates, and a PR template.
- Document contribution checks and private vulnerability reporting guidance.

## Verification
- Checked generated files are present under the expected repository and `.github` paths.