### PR TITLE
ci(docker): publish SBOM and provenance attestations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,6 +116,8 @@ jobs:
             APP_VERSION=${{ needs.setup-env.outputs.app-version }}
             DOCS_URL=${{ needs.setup-env.outputs.docs-url }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: ${{ inputs.publish && 'mode=max' || 'false' }}
+          sbom: ${{ inputs.publish }}
           cache-from: type=gha,scope=buildkit-${{ matrix.architecture }}
           cache-to: type=gha,mode=max,scope=buildkit-${{ matrix.architecture }}
 


### PR DESCRIPTION
## Summary
- Enable BuildKit SBOM and provenance attestations for published Docker images.
- Keep non-publish PR builds using local/test outputs without registry attestations.

## Verification
- `nix shell nixpkgs#actionlint --command actionlint -shellcheck= .github/workflows/build.yml`

Note: full `actionlint` with shellcheck still reports existing unrelated shellcheck warnings in this workflow.