### PR TITLE
ci(web): align tests with Docker Node version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
         default: ubuntu-latest
 
 env:
-  NODE_VERSION: 24
+  NODE_VERSION: 26
   JAVA_VERSION: 17
   DOCKER_IMAGE: elkozmon/zoonavigator
   DOCS_URL: https://zoonavigator.elkozmon.com

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ on:
         default: false
 
 env:
-  NODE_VERSION: 24
+  NODE_VERSION: 26
   JAVA_VERSION: 17
   PYTHON_VERSION: 3.13
 


### PR DESCRIPTION
## Summary
- Use Node 26 for GitHub Actions web/e2e checks.
- Align CI's Node version with the Dockerfile frontend build stage (`node:26-trixie-slim`).
- Keep CI on one Node major because the shipped artifact is built with one Node toolchain.

## Verification
- `nix shell nixpkgs#actionlint --command actionlint .github/workflows/test.yml`
- `nix shell nixpkgs#actionlint --command actionlint -shellcheck= .github/workflows/build.yml`