### PR TITLE
[codex] Patch http-proxy-middleware vulnerabilities

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -411,9 +411,9 @@
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/http-proxy-middleware": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
-      "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz",
+      "integrity": "sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -425,7 +425,7 @@
         "micromatch": "^4.0.8"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^14.18.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/is-plain-object": {
@@ -16867,7 +16867,7 @@
         "css-loader": "7.1.4",
         "esbuild": "0.28.1",
         "esbuild-wasm": "0.28.1",
-        "http-proxy-middleware": "3.0.5",
+        "http-proxy-middleware": "3.0.7",
         "istanbul-lib-instrument": "6.0.3",
         "jsonc-parser": "3.3.1",
         "karma-source-map-support": "1.4.0",
@@ -16900,9 +16900,9 @@
       },
       "dependencies": {
         "http-proxy-middleware": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
-          "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz",
+          "integrity": "sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==",
           "dev": true,
           "requires": {
             "@types/http-proxy": "^1.17.15",

--- a/web/package.json
+++ b/web/package.json
@@ -83,6 +83,9 @@
   },
   "overrides": {
     "@babel/core": "7.29.6",
+    "@angular-devkit/build-angular": {
+      "http-proxy-middleware": "3.0.7"
+    },
     "sockjs": {
       "uuid": "11.1.1"
     },


### PR DESCRIPTION
## What changed

- Override Angular's transitive `http-proxy-middleware` dependency from 3.0.5 to 3.0.7.
- Regenerate `web/package-lock.json` with the patched package metadata.

## Why

This addresses both open advisories affecting the same transitive installation:

- GHSA-gcq2-9pq2-cxqm / CVE-2026-55603 (high): multipart/form-data field injection through unescaped CRLF in `fixRequestBody`.
- GHSA-64mm-vxmg-q3vj / CVE-2026-55602 (medium): host-header-driven backend routing bypass in `router` matching.

The first version patched for both advisories is 3.0.7.

## Impact

Development tooling no longer installs the vulnerable 3.0.5 release. Runtime application dependencies are unchanged.

## Validation

- `npm ci --prefix web --ignore-scripts --no-audit --no-fund`
- `npm ls --prefix web http-proxy-middleware`
- `npm run --prefix web lint`