### PR TITLE
[codex] Ignore incompatible sbt major upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -83,6 +83,9 @@ updates:
       - dependency-name: "org.scala-lang:scala-library"
         update-types:
           - "version-update:semver-major"
+      - dependency-name: "org.scala-sbt:sbt"
+        update-types:
+          - "version-update:semver-major"
     groups:
       api-sbt-minor-patch:
         patterns:


### PR DESCRIPTION
## Summary

- ignore major updates for `org.scala-sbt:sbt` in the API Dependabot configuration
- continue allowing sbt 1.x minor and patch updates
- prevent incompatible upgrade PRs such as #222

## Root cause

The API configuration already ignored Scala major upgrades, but the sbt launcher did not have the equivalent guard. Dependabot therefore proposed the incompatible sbt 1.x to 2.x transition.

## Validation

- parsed `.github/dependabot.yml` as YAML
- asserted the sbt major-version ignore rule is present
- ran `git diff --check`