### PR TITLE
[codex] Patch Piscina prototype-pollution vulnerability

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12847,10 +12847,11 @@
       }
     },
     "node_modules/piscina": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.1.4.tgz",
-      "integrity": "sha512-7uU4ZnKeQq22t9AsmHGD2w4OYQGonwFnTypDypaWi7Qr2EvQIFVtG8J5D/3bE7W123Wdc9+v4CZDu5hJXVCtBg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.2.0.tgz",
+      "integrity": "sha512-DszUCKeVN/5G5QKo6jAVHL8fmKnkJvQ0ACiVgY7YGCq3TUB2oznAOayvZPIAdEThvhczkXR+qm3IHsNXpFCYfA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=20.x"
       },
@@ -16879,7 +16880,7 @@
         "open": "11.0.0",
         "ora": "9.4.0",
         "picomatch": "4.0.4",
-        "piscina": "5.1.4",
+        "piscina": "5.2.0",
         "postcss": "8.5.13",
         "postcss-loader": "8.2.1",
         "resolve-url-loader": "5.0.0",
@@ -17045,7 +17046,7 @@
         "mrmime": "2.0.1",
         "parse5-html-rewriting-stream": "8.0.1",
         "picomatch": "4.0.4",
-        "piscina": "5.1.4",
+        "piscina": "5.2.0",
         "rollup": "4.60.2",
         "sass": "1.99.0",
         "semver": "7.7.4",
@@ -24975,9 +24976,9 @@
       "optional": true
     },
     "piscina": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.1.4.tgz",
-      "integrity": "sha512-7uU4ZnKeQq22t9AsmHGD2w4OYQGonwFnTypDypaWi7Qr2EvQIFVtG8J5D/3bE7W123Wdc9+v4CZDu5hJXVCtBg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.2.0.tgz",
+      "integrity": "sha512-DszUCKeVN/5G5QKo6jAVHL8fmKnkJvQ0ACiVgY7YGCq3TUB2oznAOayvZPIAdEThvhczkXR+qm3IHsNXpFCYfA==",
       "dev": true,
       "requires": {
         "@napi-rs/nice": "^1.0.4"

--- a/web/package.json
+++ b/web/package.json
@@ -86,6 +86,7 @@
     "sockjs": {
       "uuid": "11.1.1"
     },
+    "piscina": "5.2.0",
     "webpack-dev-server": "5.2.5"
   }
 }


### PR DESCRIPTION
## What changed

- Override the transitive `piscina` dependency from 5.1.4 to 5.2.0.
- Regenerate `web/package-lock.json` with the patched package metadata.

## Why

This addresses GHSA-x9g3-xrwr-cwfg / CVE-2026-55388 (high), where inherited `options.filename` values can form a prototype-pollution gadget leading to remote code execution in affected uses.

## Impact

Angular development tooling now installs the first patched Piscina release. Runtime application dependencies are unchanged.

## Validation

- `npm install --prefix web --ignore-scripts --no-audit --no-fund`
- `npm ls --prefix web piscina`
- `npm run --prefix web lint`