### PR TITLE
[codex] Patch webpack-dev-server vulnerability

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15750,10 +15750,11 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
-      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
+      "integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -16876,7 +16877,7 @@
         "tslib": "2.8.1",
         "webpack": "5.106.2",
         "webpack-dev-middleware": "8.0.3",
-        "webpack-dev-server": "5.2.4",
+        "webpack-dev-server": "5.2.5",
         "webpack-merge": "6.0.1",
         "webpack-subresource-integrity": "5.1.0"
       },
@@ -26734,9 +26735,9 @@
       }
     },
     "webpack-dev-server": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
-      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
+      "integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
       "dev": true,
       "requires": {
         "@types/bonjour": "^3.5.13",

--- a/web/package.json
+++ b/web/package.json
@@ -85,6 +85,6 @@
     "sockjs": {
       "uuid": "11.1.1"
     },
-    "webpack-dev-server": "5.2.4"
+    "webpack-dev-server": "5.2.5"
   }
 }


### PR DESCRIPTION
## What changed

- Raise the existing `webpack-dev-server` override from 5.2.4 to 5.2.5.
- Regenerate `web/package-lock.json` with the patched package metadata.

## Why

This addresses GHSA-mx8g-39q3-5c79 / CVE-2026-9595 (medium), where permissive user proxy configurations can allow interception of the development server's HMR WebSocket.

## Impact

Local Angular development uses the first patched webpack-dev-server release. Production runtime dependencies are unchanged.

## Validation

- `npm install --prefix web --ignore-scripts --no-audit --no-fund`
- `npm ls --prefix web webpack-dev-server`
- `npm run --prefix web lint`